### PR TITLE
Allow encrypted configuration values in <system_configuration>

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ to do this for many values and different scopes this can get confusing.
 Alternatively you can use a special `system_config` node for setting values. It supports scopes the same way you know
 it from the `default`, `websites` and `stores` nodes in `config.xml`.
 
+Use `encrypt="true"` to set an encrypted configuration value.
+
     <?xml version="1.0"?>
     <config>
         <global>

--- a/app/code/community/LimeSoda/EnvironmentConfiguration/Model/SystemConfiguration.php
+++ b/app/code/community/LimeSoda/EnvironmentConfiguration/Model/SystemConfiguration.php
@@ -14,10 +14,11 @@ class LimeSoda_EnvironmentConfiguration_Model_SystemConfiguration
             foreach ($firstLevel->children() as $second => $secondLevel) {
                 foreach($secondLevel->children() as $third => $thirdLevel) {
                     $third = $thirdLevel->getName();
+                    $encrypt = strval($thirdLevel['encrypt']) !== '';
 
                     $key = 'system_configuration_default_' . $first . '_' . $second . '_' . $third;
                     $path = $first . '/' . $second . '/' . $third;
-                    $result[$key] = 'config:set "' . $path . '" "' . strval($thirdLevel) . '"';
+                    $result[$key] = sprintf('config:set %s "%s" "%s"', $encrypt ? '--encrypt' : '', $path, $thirdLevel);
                 }
             }
         }
@@ -58,10 +59,13 @@ class LimeSoda_EnvironmentConfiguration_Model_SystemConfiguration
                 foreach ($firstLevel->children() as $second => $secondLevel) {
                     foreach($secondLevel->children() as $third => $thirdLevel) {
                         $third = $thirdLevel->getName();
+                        $encrypt = strval($thirdLevel['encrypt']) !== '';
 
                         $key = 'system_configuration_stores_' . $storeName . '_' . $first . '_' . $second . '_' . $third;
                         $path = $first . '/' . $second . '/' . $third;
-                        $result[$key] = 'config:set --scope="stores" --scope-id="' . $storeId . '" "' . $path . '" "' . strval($thirdLevel) . '"';
+                        $result[$key] = sprintf(
+                            'config:set %s --scope="stores" --scope-id="%d" "%s" "%s"',
+                            $encrypt ? '--encrypt' : '', $storeId, $path, $thirdLevel);
                     }
                 }
             }
@@ -103,10 +107,13 @@ class LimeSoda_EnvironmentConfiguration_Model_SystemConfiguration
                 foreach ($firstLevel->children() as $second => $secondLevel) {
                     foreach($secondLevel->children() as $third => $thirdLevel) {
                         $third = $thirdLevel->getName();
+                        $encrypt = strval($thirdLevel['encrypt']) !== '';
 
                         $key = 'system_configuration_websites_' . $websiteName . '_' . $first . '_' . $second . '_' . $third;
                         $path = $first . '/' . $second . '/' . $third;
-                        $result[$key] = 'config:set --scope="websites" --scope-id="' . $websiteId . '" "' . $path . '" "' . strval($thirdLevel) . '"';
+                        $result[$key] = sprintf(
+                            'config:set %s --scope="websites" --scope-id="%d" "%s" "%s"',
+                            $encrypt ? '--encrypt' : '', $websiteId, $path, $thirdLevel);
                     }
                 }
             }


### PR DESCRIPTION
Currently if you want to set encrypted config values, you have to resort to `config:set --encrypt`. With these changes, it will also be possible to add an `encrypt="true"` attribute to a config node in `<system_configuration>` to encrypt the given configuration value.