### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@ You can use this `config.xml` skeleton as a starting point for your environment 
 		<global>
 			<limesoda>
 				<environments>
-					<default parent="default">
+					<default>
 						<variables>
 						</variables>
 						<commands>


### PR DESCRIPTION
Removed `parent="default"` from <default> node in configuration skeleton, causes nesting error