### PR TITLE
Add compatibility to Magento patch SUPEE-6285 (validating admin ACL)

### DIFF
--- a/app/code/community/LimeSoda/EnvironmentConfiguration/controllers/Adminhtml/LimeSoda/EnvironmentConfigurationController.php
+++ b/app/code/community/LimeSoda/EnvironmentConfiguration/controllers/Adminhtml/LimeSoda/EnvironmentConfigurationController.php
@@ -2,6 +2,16 @@
 
 class LimeSoda_EnvironmentConfiguration_Adminhtml_LimeSoda_EnvironmentConfigurationController extends Mage_Adminhtml_Controller_Action
 {
+    /**
+     * check against ACL
+     *
+     * @return bool - access is allowed
+     */
+    protected function _isAllowed()
+    {
+        return Mage::getSingleton('admin/session')->isAllowed('system/limesoda_environmentconfiguration');
+    }
+
     public function indexAction()
     {
         $this->loadLayout();


### PR DESCRIPTION
If you update to Magento 1.9.2.1 and you try to visit System -> Environment Configuration, you get an access denied because of changes made in  SUPEE-6285. This patch will add some validation of the admin ACL in the controller.